### PR TITLE
Add update stego

### DIFF
--- a/src/components/cli-interface.test.ts
+++ b/src/components/cli-interface.test.ts
@@ -20,31 +20,53 @@ test('(Property) addCredential should return name and value', async () => {
 	expect(response.value).toBe('secret value')
 })
 
-test('(Property) editCredentials should return the edited credentials', async () => {
-	enquirer.prompt = jest.fn().mockResolvedValueOnce({})
+describe('(Property) editCredentials', () => {
+	test('should return the edited credentials', async () => {
+		enquirer.prompt = jest.fn().mockResolvedValueOnce({})
 
-	const terminal = new CLIInterface()
-	await terminal.editCredentials({
-		secret: 'word',
-		'another Secret': 'wonderful',
+		const terminal = new CLIInterface()
+		await terminal.editCredentials({
+			secret: 'word',
+			'another Secret': 'wonderful',
+		})
+
+		expect(enquirer.prompt).toHaveBeenCalledWith({
+			choices: [
+				{
+					initial: 'word',
+					message: 'secret',
+					name: 'secret',
+				},
+				{
+					initial: 'wonderful',
+					message: 'another Secret',
+					name: 'anotherSecret',
+				},
+			],
+			message: 'Current Credentials:',
+			name: 'editedCredentials',
+			type: 'form',
+		})
 	})
 
-	expect(enquirer.prompt).toHaveBeenCalledWith({
-		choices: [
-			{
-				initial: 'word',
-				message: 'secret',
-				name: 'secret',
-			},
-			{
-				initial: 'wonderful',
-				message: 'another Secret',
-				name: 'anotherSecret',
-			},
-		],
-		message: 'Current Credentials:',
-		name: 'editedCredentials',
-		type: 'form',
+	test('should display error messages and throw error', async () => {
+		enquirer.prompt = jest.fn().mockResolvedValueOnce({})
+		const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+		const terminal = new CLIInterface()
+
+		expect(
+			terminal.editCredentials({
+				secret: ['word'],
+				'another Secret': 9,
+			}),
+		).rejects.toThrow(Error)
+		expect(error).toHaveBeenCalledTimes(1)
+		expect(error).toHaveBeenCalledWith(
+			'Credential',
+			'secret',
+			'is not typeof string. This program only supports embedding strings',
+		)
 	})
 })
 

--- a/src/components/cli-interface.ts
+++ b/src/components/cli-interface.ts
@@ -33,11 +33,19 @@ export class CLIInterface {
 	}
 
 	public async editCredentials(
-		currentCredentials: Record<string, string>,
-	): Promise<Record<string, string>> {
+		currentCredentials: Record<string, unknown>,
+	): Promise<Record<string, Record<string, unknown>>> {
 		const mappedCredentials: iCredentialFormInput[] = Object.entries(
 			currentCredentials,
 		).map(credential => {
+			if (typeof credential[1] !== 'string') {
+				console.error(
+					'Credential',
+					credential[0],
+					'is not typeof string. This program only supports embedding strings',
+				)
+				throw new Error('Credential is not string')
+			}
 			const credentialFullName = credential[0]
 			const credentialValue = credential[1]
 			const credentialCodeName = camelCase(credentialFullName)

--- a/src/components/openStego.test.ts
+++ b/src/components/openStego.test.ts
@@ -1,10 +1,14 @@
 import child_process from 'node:child_process'
+import * as fs from 'node:fs'
 import { Config } from '../utils/config'
 import { OpenStego } from './openStego'
 
-jest.mock('../utils/config')
 jest.mock('node:child_process')
+jest.mock('node:fs')
+jest.mock('../utils/config')
+
 const mockedChild_process = child_process as jest.Mocked<typeof child_process>
+const mockedFs = fs as jest.Mocked<typeof fs>
 
 let config: Config
 let openStego: OpenStego
@@ -32,13 +36,13 @@ beforeAll(() => {
 	openStego = new OpenStego(config)
 })
 
-afterAll(() => {
+afterEach(() => {
 	jest.resetAllMocks()
 })
 
 test('Config contructor should call config functions', () => {
 	new OpenStego(config)
-	expect(config.getPath).toHaveBeenCalledTimes(3)
+	expect(config.getPath).toHaveBeenCalledTimes(4)
 })
 
 describe('(Property) decryptStego', () => {
@@ -128,5 +132,207 @@ describe('(Property) decryptStego', () => {
 		expect(error).toHaveBeenNthCalledWith(2, 'Error: Mocked error')
 
 		expect(() => openStego.decryptStego({})).toThrow('throwing random text')
+	})
+})
+
+describe('(Property) updateStego', () => {
+	const testSecrets =
+		'{"1Password password":"b!bKDTYUKg6weftyR7*IwpwefWFExh2r*FdT","1Password SecretKey":"ag-erggh-y3456u-3hjne-23yjhd4-23ygd436-at3wy45"}'
+	const info = jest.spyOn(console, 'info').mockImplementation(() => {})
+	const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+	test('should parse the recieved data and call the execSync command', () => {
+		mockedChild_process.execSync.mockImplementation(jest.fn())
+		mockedFs.writeFileSync.mockImplementation(jest.fn())
+
+		openStego.updateStego({
+			updatedSecrets: JSON.parse(testSecrets),
+			stegoPassword: 'welp',
+		})
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(1)
+		expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+			'hiddenFile/path/file.json',
+			testSecrets,
+		)
+		expect(mockedChild_process.execSync).toHaveBeenCalledTimes(3)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			1,
+			'mv stego/path/stego.bmp ./tmp/stegoOld.bmp',
+			{ encoding: 'utf8' },
+		)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			2,
+			'java -jar jar/path/openstego.jar embed -mf hiddenFile/path/file.json -cf coverImage/path/image.jpg -sf stego/path/stego.bmp -e -A AES256 -p welp',
+			{ encoding: 'utf8' },
+		)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			3,
+			'rm hiddenFile/path/file.json',
+			{ encoding: 'utf8' },
+		)
+		expect(info).toHaveBeenCalledWith('Steganography file updated successfully')
+	})
+
+	test('should gracefully handle when WriteFileSync throws error', () => {
+		mockedChild_process.execSync.mockImplementationOnce(jest.fn())
+		mockedFs.writeFileSync.mockImplementation(
+			jest.fn(() => {
+				throw new Error('Failed writing file for some reason')
+			}),
+		)
+
+		openStego.updateStego({ updatedSecrets: JSON.parse(testSecrets) })
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(1)
+		expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+			'hiddenFile/path/file.json',
+			testSecrets,
+		)
+		expect(mockedChild_process.execSync).not.toHaveBeenCalled()
+		expect(error).toHaveBeenCalledTimes(2)
+		expect(error).toHaveBeenNthCalledWith(
+			1,
+			'Failed to write secrets to temporary Hidden file',
+		)
+		expect(error).toHaveBeenNthCalledWith(
+			2,
+			Error('Failed writing file for some reason'),
+		)
+	})
+
+	test('should display error when backup command throws error', () => {
+		mockedChild_process.execSync.mockImplementationOnce(
+			jest.fn(() => {
+				throw new Error('Command failed')
+			}),
+		)
+		mockedFs.writeFileSync.mockImplementation(jest.fn())
+
+		expect(() =>
+			openStego.updateStego({ updatedSecrets: JSON.parse(testSecrets) }),
+		).toThrow(Error('Command failed'))
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalled()
+		expect(mockedChild_process.execSync).toHaveBeenCalledTimes(1)
+		expect(mockedChild_process.execSync).toHaveBeenCalledWith(
+			'mv stego/path/stego.bmp ./tmp/stegoOld.bmp',
+			{ encoding: 'utf8' },
+		)
+		expect(error).toHaveBeenCalledTimes(3)
+		expect(error).toHaveBeenNthCalledWith(
+			1,
+			'Error executing command: mv stego/path/stego.bmp ./tmp/stegoOld.bmp',
+		)
+		expect(error).toHaveBeenNthCalledWith(2, 'Error: Command failed')
+		expect(error).toHaveBeenNthCalledWith(
+			3,
+			'Failed to backup stego File. Please check if you stego file exists',
+		)
+	})
+
+	test('should display error and restore backup stego when embed command throws error', () => {
+		mockedChild_process.execSync
+			.mockImplementationOnce(jest.fn()) // pass backup command
+			.mockImplementationOnce(
+				jest.fn(() => {
+					throw new Error('Embed failed')
+				}),
+			)
+			.mockImplementationOnce(jest.fn()) // pass restore command
+		mockedFs.writeFileSync.mockImplementation(jest.fn())
+
+		expect(() =>
+			openStego.updateStego({ updatedSecrets: JSON.parse(testSecrets) }),
+		).toThrow(Error('Embed failed'))
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalled()
+		expect(mockedChild_process.execSync).toHaveBeenCalledTimes(3)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			3,
+			'mv ./tmp/stegoOld.bpm stego/path/stego.bmp',
+			{ encoding: 'utf8' },
+		)
+		expect(error).toHaveBeenCalledTimes(3)
+		expect(error).toHaveBeenNthCalledWith(
+			1,
+			'Error executing command: java -jar jar/path/openstego.jar embed -mf hiddenFile/path/file.json -cf coverImage/path/image.jpg -sf stego/path/stego.bmp',
+		)
+		expect(error).toHaveBeenNthCalledWith(2, 'Error: Embed failed')
+		expect(error).toHaveBeenNthCalledWith(
+			3,
+			'Failed to embed updated secrets. Restoring backup. Please review the error message below',
+		)
+	})
+
+	test('should display errors when embed and restore commands throw errors', () => {
+		mockedChild_process.execSync
+			.mockImplementationOnce(jest.fn()) // pass backup command
+			.mockImplementationOnce(
+				jest.fn(() => {
+					throw new Error('Embed failed')
+				}),
+			)
+			.mockImplementationOnce(
+				jest.fn(() => {
+					throw Error('Restore failed')
+				}),
+			)
+		mockedFs.writeFileSync.mockImplementation(jest.fn())
+
+		expect(() =>
+			openStego.updateStego({ updatedSecrets: JSON.parse(testSecrets) }),
+		).toThrow(Error('Embed failed'))
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalled()
+		expect(mockedChild_process.execSync).toHaveBeenCalledTimes(3)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			3,
+			'mv ./tmp/stegoOld.bpm stego/path/stego.bmp',
+			{ encoding: 'utf8' },
+		)
+		expect(error).toHaveBeenCalledTimes(6)
+		expect(error).toHaveBeenNthCalledWith(
+			4,
+			'Error executing command: mv ./tmp/stegoOld.bpm stego/path/stego.bmp',
+		)
+		expect(error).toHaveBeenNthCalledWith(5, 'Error: Restore failed')
+		expect(error).toHaveBeenNthCalledWith(
+			6,
+			'Panic!!! Failed to restore backup of Stego file. You should be able to find the file in',
+			'/home/tebrithiel/cli-OpenStego/cli-OpenStego/tmp/stegoOld.bmp',
+		)
+	})
+
+	test('should display errors when cleanFile command throws error', () => {
+		mockedChild_process.execSync
+			.mockImplementationOnce(jest.fn()) // pass backup command
+			.mockImplementationOnce(jest.fn()) // pass embed command
+			.mockImplementationOnce(
+				jest.fn(() => {
+					throw Error('CleanFile failed')
+				}),
+			)
+		mockedFs.writeFileSync.mockImplementation(jest.fn())
+
+		openStego.updateStego({ updatedSecrets: JSON.parse(testSecrets) })
+
+		expect(mockedFs.writeFileSync).toHaveBeenCalled()
+		expect(mockedChild_process.execSync).toHaveBeenCalledTimes(3)
+		expect(mockedChild_process.execSync).toHaveBeenNthCalledWith(
+			3,
+			'rm hiddenFile/path/file.json',
+			{ encoding: 'utf8' },
+		)
+		expect(error).toHaveBeenCalledTimes(3)
+		expect(error).toHaveBeenNthCalledWith(
+			1,
+			'Error executing command: rm hiddenFile/path/file.json',
+		)
+		expect(error).toHaveBeenNthCalledWith(2, 'Error: CleanFile failed')
+		expect(error).toHaveBeenNthCalledWith(
+			3,
+			'Failed to clean up the hidden file. For security purposes please manually delete the file located here: hiddenFile/path/file.json',
+		)
 	})
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,18 @@ async function main() {
 	const openStego = new OpenStego(config)
 	const { stegoPassword } = await terminal.getStegoPassword()
 
-	const test1 = openStego.decryptStego({ stegoPassword })
-	console.log(typeof test1)
+	const decryptedStego = openStego.decryptStego({ stegoPassword }) as Record<
+		string,
+		string
+	>
+
+	console.log(decryptedStego)
 
 	const test2 = await terminal.addCredential()
 
 	console.log(test2)
 
-	const edited = await terminal.editCredentials(testCredentials)
+	const edited = await terminal.editCredentials(decryptedStego)
 
 	console.log(edited)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,18 @@ async function main() {
 	const edited = await terminal.editCredentials(decryptedStego)
 
 	console.log(edited)
+
+	openStego.updateStego({
+		updatedSecrets: edited.editedCredentials,
+		stegoPassword,
+	})
+
+	const updatedStego = openStego.decryptStego({ stegoPassword }) as Record<
+		string,
+		string
+	>
+
+	console.log(updatedStego)
 }
 
 main()


### PR DESCRIPTION
Updated OpenStego to have new property updateStego

The program needs to be able to handle the scenario when the user wants to update the contents of an existing Stego
The updateStego property accepts multiple configuration variables to control the behaviour.
It writes the updated secrets to a new file, backs up the stego file to a temp holding folder and renames it as a precaution.
After the backup is successful, it creates a new stego file using the newly created secret file and the provided config.
If the creation is unsuccessful, the backup is then restored to the original location and appropriate errors are displayed.
With the successful creation of the new stego, the secret file is deleted to protect the data and a success message is displayed